### PR TITLE
Improvements + hour_minute_second occurence

### DIFF
--- a/any_schedule.go
+++ b/any_schedule.go
@@ -20,7 +20,7 @@ func (self AnySchedule) IsOccurring(t time.Time) bool {
 }
 
 // Implement Schedule interface.
-func (self AnySchedule) Occurrences(t TimeRange) chan time.Time {
+func (self AnySchedule) Occurrences(t TimeRange) []time.Time {
 	return self.Schedule.Occurrences(t)
 }
 

--- a/date.go
+++ b/date.go
@@ -15,7 +15,7 @@ func (self Date) IsOccurring(t time.Time) bool {
 }
 
 // Implement Schedule interface.
-func (self Date) Occurrences(tr TimeRange) chan time.Time {
+func (self Date) Occurrences(tr TimeRange) []time.Time {
 	return occurrencesFor(self, tr)
 }
 

--- a/date_test.go
+++ b/date_test.go
@@ -59,13 +59,6 @@ func BenchmarkDateOccurrences(b *testing.B) {
 	d := NewDate("2525-01-01")
 	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
 	for n := 0; n < b.N; n++ {
-		ch := d.Occurrences(tr)
-		for {
-			_, ok := <-ch
-
-			if !ok {
-				break
-			}
-		}
+		d.Occurrences(tr)
 	}
 }

--- a/day.go
+++ b/day.go
@@ -20,7 +20,7 @@ func (self Day) IsOccurring(t time.Time) bool {
 }
 
 // Implement Schedule interface.
-func (self Day) Occurrences(tr TimeRange) chan time.Time {
+func (self Day) Occurrences(tr TimeRange) []time.Time {
 	return occurrencesFor(self, tr)
 }
 

--- a/day_test.go
+++ b/day_test.go
@@ -112,13 +112,6 @@ func BenchmarkDayOccurrences(b *testing.B) {
 	d := Day(1)
 	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
 	for n := 0; n < b.N; n++ {
-		ch := d.Occurrences(tr)
-		for {
-			_, ok := <-ch
-
-			if !ok {
-				break
-			}
-		}
+		d.Occurrences(tr)
 	}
 }

--- a/hour_minute_second.go
+++ b/hour_minute_second.go
@@ -25,7 +25,7 @@ func (hms HourMinuteSecond) IsOccurring(t time.Time) bool {
 		int(hms.second) == t.Second()
 }
 
-func (hms HourMinuteSecond) Occurrences(tr TimeRange) chan time.Time {
+func (hms HourMinuteSecond) Occurrences(tr TimeRange) []time.Time {
 	return occurrencesFor(hms, tr)
 }
 
@@ -58,8 +58,6 @@ func (hms *HourMinuteSecond) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &m); err != nil {
 		return err
 	}
-
-	fmt.Printf("********** %v\n", m)
 
 	hourI, ok := m["hour"]
 	if !ok {

--- a/hour_minute_second.go
+++ b/hour_minute_second.go
@@ -1,6 +1,8 @@
 package recurrence
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -39,4 +41,55 @@ func (hms HourMinuteSecond) nextAfter(t time.Time) (time.Time, error) {
 
 	// Otherwise the event is scheduled for the next day
 	return thms.AddDate(0, 0, 1), nil
+}
+
+// MarshalJSON returns a marshaled version of the underlying HourMinuteSecond instance
+func (hms HourMinuteSecond) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"hour":   hms.hour,
+		"minute": hms.minute,
+		"second": hms.second,
+	})
+}
+
+// UnmarshalJSON populates the *HourMinuteSecond pointer with values from the marshaled JSON bytes
+func (hms *HourMinuteSecond) UnmarshalJSON(b []byte) error {
+	m := map[string]interface{}{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+
+	fmt.Printf("********** %v\n", m)
+
+	hourI, ok := m["hour"]
+	if !ok {
+		return fmt.Errorf("Missing 'hour' field")
+	}
+	if hour, ok := hourI.(float64); !ok {
+		return fmt.Errorf("'hour' field should be integer")
+	} else {
+		hms.hour = int(hour)
+	}
+
+	minuteI, ok := m["minute"]
+	if !ok {
+		return fmt.Errorf("Missing 'minute' field")
+	}
+	if minute, ok := minuteI.(float64); !ok {
+		return fmt.Errorf("'minute' field should be integer")
+	} else {
+		hms.minute = int(minute)
+	}
+
+	secondI, ok := m["second"]
+	if !ok {
+		return fmt.Errorf("Missing 'second' field")
+	}
+	if second, ok := secondI.(float64); !ok {
+		return fmt.Errorf("'second' field should be integer")
+	} else {
+		hms.second = int(second)
+	}
+
+	return nil
 }

--- a/hour_minute_second.go
+++ b/hour_minute_second.go
@@ -1,0 +1,42 @@
+package recurrence
+
+import (
+	"time"
+)
+
+// HourMinuteSecond encapsulates the hour, minute and second components of a time
+type HourMinuteSecond struct {
+	hour   int
+	minute int
+	second int
+}
+
+// NewHourMinuteSeconds is a convenience constructor method to create an instance of NewHourMinuteSeconds
+func NewHourMinuteSeconds(h, m, s int) HourMinuteSecond {
+	return HourMinuteSecond{h, m, s}
+}
+
+// Implement Schedule interface.
+func (hms HourMinuteSecond) IsOccurring(t time.Time) bool {
+	return int(hms.hour) == t.Hour() &&
+		int(hms.minute) == t.Minute() &&
+		int(hms.second) == t.Second()
+}
+
+func (hms HourMinuteSecond) Occurrences(tr TimeRange) chan time.Time {
+	return occurrencesFor(hms, tr)
+}
+
+func (hms HourMinuteSecond) nextAfter(t time.Time) (time.Time, error) {
+	// Compare times ignoring nanoseconds
+	thms := time.Date(t.Year(), t.Month(), t.Day(), hms.hour, hms.minute, hms.second, 0, time.UTC)
+	t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), 0, time.UTC)
+
+	// This means this event is scheduled after the time that was passed
+	if t.Before(thms) {
+		return thms, nil
+	}
+
+	// Otherwise the event is scheduled for the next day
+	return thms.AddDate(0, 0, 1), nil
+}

--- a/hour_minute_second_test.go
+++ b/hour_minute_second_test.go
@@ -1,0 +1,95 @@
+package recurrence
+
+import (
+	"testing"
+	"time"
+)
+
+const hourLayout = "2006-01-02T15:04:05"
+
+func assertIsHourOccurring(t *testing.T, s Schedule, o ...string) {
+	for _, o := range o {
+		if o, _ := time.Parse(hourLayout, o); !s.IsOccurring(o) {
+			t.Errorf("%#v should have included %s", s, o)
+		}
+	}
+}
+
+func refuteIsHourOccurring(t *testing.T, s Schedule, o ...string) {
+	for _, o := range o {
+		if o, _ := time.Parse(hourLayout, o); s.IsOccurring(o) {
+			t.Errorf("%#v should not have included %s", s, o)
+		}
+	}
+}
+
+func TestHourIsOccuring(t *testing.T) {
+	hms := NewHourMinuteSeconds(14, 0, 0)
+	assertIsHourOccurring(t, hms, "2016-01-01T14:00:00", "2016-01-02T14:00:00", "2016-01-20T14:00:00")
+
+	hms = NewHourMinuteSeconds(14, 30, 0)
+	assertIsHourOccurring(t, hms, "2016-01-01T14:30:00", "2016-01-02T14:30:00", "2016-01-20T14:30:00")
+
+	hms = NewHourMinuteSeconds(14, 30, 59)
+	assertIsHourOccurring(t, hms, "2016-01-01T14:30:59", "2016-01-02T14:30:59", "2016-01-20T14:30:59")
+}
+
+func TestHourIsNotOccuring(t *testing.T) {
+	hms := NewHourMinuteSeconds(14, 0, 0)
+	refuteIsHourOccurring(t, hms, "2016-01-01T14:01:00", "2016-01-04T20:00:00", "2016-01-20T07:00:00")
+
+	hms = NewHourMinuteSeconds(14, 59, 0)
+	refuteIsHourOccurring(t, hms, "2016-01-01T14:59:50", "2016-01-04T20:12:00", "2016-01-20T14:00:00")
+
+	hms = NewHourMinuteSeconds(14, 0, 30)
+	refuteIsHourOccurring(t, hms, "2016-01-01T14:00:29", "2016-01-04T20:00:30", "2016-01-20T14:00:00")
+}
+
+func TestNextHourMinuteSecondOccurrenceSameDay(t *testing.T) {
+	hms := NewHourMinuteSeconds(14, 30, 0)
+	d := time.Date(2006, time.January, 10, 14, 0, 0, 0, time.UTC)
+	expected := time.Date(2006, time.January, 10, 14, 30, 0, 0, time.UTC)
+	n, err := hms.nextAfter(d)
+
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	if expected != n {
+		t.Errorf("Next occurences not matching [expected=%v, actual=%v]", expected, n)
+	}
+}
+
+func TestNextHourMinuteSecondOccurrenceNextDay(t *testing.T) {
+	hms := NewHourMinuteSeconds(14, 30, 0)
+	d := time.Date(2006, time.January, 10, 16, 0, 0, 0, time.UTC)
+	expected := time.Date(2006, time.January, 11, 14, 30, 0, 0, time.UTC)
+	n, err := hms.nextAfter(d)
+
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+
+	if expected != n {
+		t.Errorf("Next occurences not matching [expected=%v, actual=%v]", expected, n)
+	}
+}
+
+func TestNextHourMinuteSecondOccurences(t *testing.T) {
+	hms := NewHourMinuteSeconds(14, 30, 0)
+	tr := TimeRange{time.Time(NewDate("2006-01-01")), time.Time(NewDate("2006-01-31"))}
+	nextDates := make([]time.Time, 0)
+
+	for r := range tr.eachDate() {
+		tn, err := hms.nextAfter(r)
+		if err != nil {
+			t.Errorf("Unable to get next time after [hms=%v, date=%v]: %v", hms, r, err)
+		}
+		nextDates = append(nextDates, tn)
+	}
+
+	expectedDays := 31
+	if len(nextDates) != expectedDays {
+		t.Errorf("Was expecting %d days but instead got %d instead", expectedDays, len(nextDates))
+	}
+}

--- a/hour_minute_second_test.go
+++ b/hour_minute_second_test.go
@@ -93,3 +93,40 @@ func TestNextHourMinuteSecondOccurences(t *testing.T) {
 		t.Errorf("Was expecting %d days but instead got %d instead", expectedDays, len(nextDates))
 	}
 }
+
+func TestMarshalHourMinuteSecondJSON(t *testing.T) {
+	hms := NewHourMinuteSeconds(14, 30, 0)
+	js, err := hms.MarshalJSON()
+	if err != nil {
+		t.Errorf("Unable to marshal Minute Hour Second: %v", err)
+	}
+
+	expected := `{"hour":14,"minute":30,"second":0}`
+
+	if string(js) != expected {
+		t.Errorf("Expected and actual marshaled strings differ [expected=%s, actual=%s]", expected, string(js))
+	}
+}
+
+func TestUnmarshalHourMinuteSecondJSON(t *testing.T) {
+	js := `{"hour":14,"minute":30,"second":0}`
+	hms := new(HourMinuteSecond)
+
+	err := hms.UnmarshalJSON([]byte(js))
+	if err != nil {
+		t.Errorf("Unable to unmarshal: %v", err)
+	}
+
+	if hms.hour != 14 {
+		t.Errorf("Hours differ: [expected=%d, actual=%d]", 14, hms.hour)
+	}
+
+	if hms.minute != 30 {
+		t.Errorf("Minutes differ: [expected=%d, actual=%d]", 30, hms.minute)
+	}
+
+	if hms.second != 0 {
+		t.Errorf("Seconds differ: [expected=%d, actual=%d]", 14, hms.second)
+	}
+
+}

--- a/intersection.go
+++ b/intersection.go
@@ -12,7 +12,7 @@ type Intersection []Schedule
 // Implement Schedule interface.
 func (self Intersection) IsOccurring(t time.Time) bool {
 	for _, r := range self {
-		if r.IsOccurring(t) == false {
+		if !r.IsOccurring(t) {
 			return false
 		}
 	}

--- a/intersection_test.go
+++ b/intersection_test.go
@@ -83,13 +83,6 @@ func BenchmarkIntersectionOccurrences(b *testing.B) {
 	d := Intersection{November, Thursday, Week(4)}
 	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
 	for n := 0; n < b.N; n++ {
-		ch := d.Occurrences(tr)
-		for {
-			_, ok := <-ch
-
-			if !ok {
-				break
-			}
-		}
+		d.Occurrences(tr)
 	}
 }

--- a/intersection_test.go
+++ b/intersection_test.go
@@ -59,6 +59,26 @@ func TestIntersectionUnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestIntersectionDayAndHourMinuteSecondOccuring(t *testing.T) {
+	dhms := Intersection{Union{Saturday, Sunday}, NewHourMinuteSeconds(14, 30, 0)}
+	// Today is Sunday 14/02/2016
+	today := time.Date(2016, time.February, 14, 14, 30, 0, 0, time.UTC)
+
+	if !dhms.IsOccurring(today) {
+		t.Errorf("Event should be scheduled today: %v", today)
+	}
+
+	nextWeek := today.AddDate(0, 0, 6)
+	if !dhms.IsOccurring(nextWeek) {
+		t.Errorf("Event should be scheduled next Saturday too: %v", nextWeek)
+	}
+
+	nextWeek = nextWeek.AddDate(0, 0, 1)
+	if !dhms.IsOccurring(nextWeek) {
+		t.Errorf("Event should be scheduled next Sunday too: %v", nextWeek)
+	}
+}
+
 func BenchmarkIntersectionOccurrences(b *testing.B) {
 	d := Intersection{November, Thursday, Week(4)}
 	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}

--- a/month.go
+++ b/month.go
@@ -35,7 +35,7 @@ func (self Month) IsOccurring(t time.Time) bool {
 }
 
 // Implement Schedule interface.
-func (self Month) Occurrences(tr TimeRange) chan time.Time {
+func (self Month) Occurrences(tr TimeRange) []time.Time {
 	return occurrencesFor(self, tr)
 }
 

--- a/month_test.go
+++ b/month_test.go
@@ -192,13 +192,6 @@ func BenchmarkMonthOccurrences(b *testing.B) {
 	d := January
 	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
 	for n := 0; n < b.N; n++ {
-		ch := d.Occurrences(tr)
-		for {
-			_, ok := <-ch
-
-			if !ok {
-				break
-			}
-		}
+		d.Occurrences(tr)
 	}
 }

--- a/schedule.go
+++ b/schedule.go
@@ -10,6 +10,7 @@ type Schedule interface {
 	Occurrences(TimeRange) chan time.Time
 }
 
+// @todo why is this not in the schedule interface?
 type nextable interface {
 	nextAfter(time.Time) (time.Time, error)
 }

--- a/schedule.go
+++ b/schedule.go
@@ -7,7 +7,7 @@ import "time"
 // occurs in the Schedule, and generate time.Times satisfying the Schedule.
 type Schedule interface {
 	IsOccurring(time.Time) bool
-	Occurrences(TimeRange) chan time.Time
+	Occurrences(TimeRange) []time.Time
 }
 
 // @todo why is this not in the schedule interface?
@@ -15,19 +15,16 @@ type nextable interface {
 	nextAfter(time.Time) (time.Time, error)
 }
 
-func occurrencesFor(schedule nextable, timeRange TimeRange) chan time.Time {
-	ch := make(chan time.Time)
+func occurrencesFor(schedule nextable, timeRange TimeRange) []time.Time {
+	ts := make([]time.Time, 0)
+	start := timeRange.Start.AddDate(0, 0, -1)
+	end := timeRange.End
 
-	go func() {
-		start := timeRange.Start.AddDate(0, 0, -1)
-		end := timeRange.End
-		for t, err := schedule.nextAfter(start); err == nil && !t.After(end); t, err = schedule.nextAfter(t) {
-			if !t.After(end) {
-				ch <- beginningOfDay(t)
-			}
+	for t, err := schedule.nextAfter(start); err == nil && !t.After(end); t, err = schedule.nextAfter(t) {
+		if !t.After(end) {
+			ts = append(ts, beginningOfDay(t))
 		}
-		close(ch)
-	}()
+	}
 
-	return ch
+	return ts
 }

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -56,7 +56,7 @@ func assertOccurrenceGeneration(t *testing.T, tr TimeRange, expectations map[Sch
 		schedule := schedule.(Schedule)
 		var dates []time.Time
 
-		for d := range schedule.Occurrences(tr) {
+		for _, d := range schedule.Occurrences(tr) {
 			dates = append(dates, d)
 			if !schedule.IsOccurring(d) || d.Before(tr.Start) || d.After(tr.End) {
 				t.Errorf("%s.Occurrences(%v) included a date it shouldn't have: %s", schedule, tr, d)
@@ -74,7 +74,7 @@ func assertOccurrenceGeneration2(t *testing.T, tr TimeRange, expectations map[in
 		schedule := schedule.(Schedule)
 		var dates []time.Time
 
-		for d := range schedule.Occurrences(tr) {
+		for _, d := range schedule.Occurrences(tr) {
 			dates = append(dates, d)
 			if !schedule.IsOccurring(d) || d.Before(tr.Start) || d.After(tr.End) {
 				t.Errorf("%s.Occurrences(%v) included a date it shouldn't have: %s", schedule, tr, d)

--- a/time_range.go
+++ b/time_range.go
@@ -18,7 +18,7 @@ func (self TimeRange) IsOccurring(t time.Time) bool {
 }
 
 // Implement Schedule interface.
-func (self TimeRange) Occurrences(other TimeRange) chan time.Time {
+func (self TimeRange) Occurrences(other TimeRange) []time.Time {
 	return occurrencesFor(self, other)
 }
 

--- a/union_test.go
+++ b/union_test.go
@@ -1,79 +1,79 @@
 package recurrence
 
-import (
-	"encoding/json"
-	"reflect"
-	"testing"
-	"time"
-)
-
-func TestUnion(t *testing.T) {
-	u := Union{
-		OrdinalWeekday(First, Sunday),
-		Day(Last),
-	}
-	r := YearRange(2006)
-
-	assertIsOnlyOccurring(t, r, u, "2006-01-01", "2006-02-05", "2006-03-05",
-		"2006-04-02", "2006-05-07", "2006-06-04", "2006-07-02", "2006-08-06",
-		"2006-09-03", "2006-10-01", "2006-11-05", "2006-12-03", "2006-01-31",
-		"2006-02-28", "2006-03-31", "2006-04-30", "2006-05-31", "2006-06-30",
-		"2006-07-31", "2006-08-31", "2006-09-30", "2006-10-31", "2006-11-30",
-		"2006-12-31")
-}
-
-func TestUnionOccurrences(t *testing.T) {
-	tr := TimeRange{time.Time(NewDate("2006-01-01")), time.Time(NewDate("2009-12-31"))}
-
-	expectations := map[int]Schedule{
-		368: Union{June, July, August},
-		626: Union{Monday, Wednesday, Friday},
-		209: Union{Monday, Monday}, // Shouldn't duplicate days
-	}
-
-	assertOccurrenceGeneration2(t, tr, expectations)
-}
-
-func TestUnionMarshalJSON(t *testing.T) {
-	tests := map[string]Union{
-		`{"union":[{"day":1},{"day":"Last"},{"month":"January"}]}`:         Union{Day(First), Day(Last), January},
-		`{"union":[{"weekday":"Thursday"},{"week":"Last"},{"year":2012}]}`: Union{Thursday, Week(Last), Year(2012)},
-	}
-
-	for expected, input := range tests {
-		output, err := json.Marshal(input)
-		if string(output) != expected || err != nil {
-			t.Errorf("\nInput: %v\nExpected: %v\nActual: %v\nError: %v", input, expected, string(output), err)
-		}
-	}
-}
-
-func TestUnionUnmarshalJSON(t *testing.T) {
-	tests := map[string]Union{
-		`[{"day":"Last"},{"month":"January"}]`:   Union{Day(Last), January},
-		`[{"weekday":"Thursday"},{"year":2014}]`: Union{Thursday, Year(2014)},
-	}
-
-	for input, expected := range tests {
-		var output Union
-		err := json.Unmarshal([]byte(input), &output)
-		if !reflect.DeepEqual(output, expected) || err != nil {
-			t.Errorf("\nInput: %v\nExpected: %v\nActual: %v\nError: %v", input, expected, output, err)
-		}
-	}
-}
-
-func BenchmarkUnionOccurrences(b *testing.B) {
-	d := Union{January, March, May, Day(1), Day(Last)}
-	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
-	for n := 0; n < b.N; n++ {
-		ch := d.Occurrences(tr)
-		for {
-			_, ok := <-ch
-
-			if !ok {
-				break
-			}
-		}
-	}
-}
+// import (
+// 	"encoding/json"
+// 	"reflect"
+// 	"testing"
+// 	"time"
+// )
+//
+// func TestUnion(t *testing.T) {
+// 	u := Union{
+// 		OrdinalWeekday(First, Sunday),
+// 		Day(Last),
+// 	}
+// 	r := YearRange(2006)
+//
+// 	assertIsOnlyOccurring(t, r, u, "2006-01-01", "2006-02-05", "2006-03-05",
+// 		"2006-04-02", "2006-05-07", "2006-06-04", "2006-07-02", "2006-08-06",
+// 		"2006-09-03", "2006-10-01", "2006-11-05", "2006-12-03", "2006-01-31",
+// 		"2006-02-28", "2006-03-31", "2006-04-30", "2006-05-31", "2006-06-30",
+// 		"2006-07-31", "2006-08-31", "2006-09-30", "2006-10-31", "2006-11-30",
+// 		"2006-12-31")
+// }
+//
+// func TestUnionOccurrences(t *testing.T) {
+// 	tr := TimeRange{time.Time(NewDate("2006-01-01")), time.Time(NewDate("2009-12-31"))}
+//
+// 	expectations := map[int]Schedule{
+// 		368: Union{June, July, August},
+// 		626: Union{Monday, Wednesday, Friday},
+// 		209: Union{Monday, Monday}, // Shouldn't duplicate days
+// 	}
+//
+// 	assertOccurrenceGeneration2(t, tr, expectations)
+// }
+//
+// func TestUnionMarshalJSON(t *testing.T) {
+// 	tests := map[string]Union{
+// 		`{"union":[{"day":1},{"day":"Last"},{"month":"January"}]}`:         Union{Day(First), Day(Last), January},
+// 		`{"union":[{"weekday":"Thursday"},{"week":"Last"},{"year":2012}]}`: Union{Thursday, Week(Last), Year(2012)},
+// 	}
+//
+// 	for expected, input := range tests {
+// 		output, err := json.Marshal(input)
+// 		if string(output) != expected || err != nil {
+// 			t.Errorf("\nInput: %v\nExpected: %v\nActual: %v\nError: %v", input, expected, string(output), err)
+// 		}
+// 	}
+// }
+//
+// func TestUnionUnmarshalJSON(t *testing.T) {
+// 	tests := map[string]Union{
+// 		`[{"day":"Last"},{"month":"January"}]`:   Union{Day(Last), January},
+// 		`[{"weekday":"Thursday"},{"year":2014}]`: Union{Thursday, Year(2014)},
+// 	}
+//
+// 	for input, expected := range tests {
+// 		var output Union
+// 		err := json.Unmarshal([]byte(input), &output)
+// 		if !reflect.DeepEqual(output, expected) || err != nil {
+// 			t.Errorf("\nInput: %v\nExpected: %v\nActual: %v\nError: %v", input, expected, output, err)
+// 		}
+// 	}
+// }
+//
+// func BenchmarkUnionOccurrences(b *testing.B) {
+// 	d := Union{January, March, May, Day(1), Day(Last)}
+// 	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
+// 	for n := 0; n < b.N; n++ {
+// 		ch := d.Occurrences(tr)
+// 		for {
+// 			_, ok := <-ch
+//
+// 			if !ok {
+// 				break
+// 			}
+// 		}
+// 	}
+// }

--- a/union_test.go
+++ b/union_test.go
@@ -1,79 +1,72 @@
 package recurrence
 
-// import (
-// 	"encoding/json"
-// 	"reflect"
-// 	"testing"
-// 	"time"
-// )
-//
-// func TestUnion(t *testing.T) {
-// 	u := Union{
-// 		OrdinalWeekday(First, Sunday),
-// 		Day(Last),
-// 	}
-// 	r := YearRange(2006)
-//
-// 	assertIsOnlyOccurring(t, r, u, "2006-01-01", "2006-02-05", "2006-03-05",
-// 		"2006-04-02", "2006-05-07", "2006-06-04", "2006-07-02", "2006-08-06",
-// 		"2006-09-03", "2006-10-01", "2006-11-05", "2006-12-03", "2006-01-31",
-// 		"2006-02-28", "2006-03-31", "2006-04-30", "2006-05-31", "2006-06-30",
-// 		"2006-07-31", "2006-08-31", "2006-09-30", "2006-10-31", "2006-11-30",
-// 		"2006-12-31")
-// }
-//
-// func TestUnionOccurrences(t *testing.T) {
-// 	tr := TimeRange{time.Time(NewDate("2006-01-01")), time.Time(NewDate("2009-12-31"))}
-//
-// 	expectations := map[int]Schedule{
-// 		368: Union{June, July, August},
-// 		626: Union{Monday, Wednesday, Friday},
-// 		209: Union{Monday, Monday}, // Shouldn't duplicate days
-// 	}
-//
-// 	assertOccurrenceGeneration2(t, tr, expectations)
-// }
-//
-// func TestUnionMarshalJSON(t *testing.T) {
-// 	tests := map[string]Union{
-// 		`{"union":[{"day":1},{"day":"Last"},{"month":"January"}]}`:         Union{Day(First), Day(Last), January},
-// 		`{"union":[{"weekday":"Thursday"},{"week":"Last"},{"year":2012}]}`: Union{Thursday, Week(Last), Year(2012)},
-// 	}
-//
-// 	for expected, input := range tests {
-// 		output, err := json.Marshal(input)
-// 		if string(output) != expected || err != nil {
-// 			t.Errorf("\nInput: %v\nExpected: %v\nActual: %v\nError: %v", input, expected, string(output), err)
-// 		}
-// 	}
-// }
-//
-// func TestUnionUnmarshalJSON(t *testing.T) {
-// 	tests := map[string]Union{
-// 		`[{"day":"Last"},{"month":"January"}]`:   Union{Day(Last), January},
-// 		`[{"weekday":"Thursday"},{"year":2014}]`: Union{Thursday, Year(2014)},
-// 	}
-//
-// 	for input, expected := range tests {
-// 		var output Union
-// 		err := json.Unmarshal([]byte(input), &output)
-// 		if !reflect.DeepEqual(output, expected) || err != nil {
-// 			t.Errorf("\nInput: %v\nExpected: %v\nActual: %v\nError: %v", input, expected, output, err)
-// 		}
-// 	}
-// }
-//
-// func BenchmarkUnionOccurrences(b *testing.B) {
-// 	d := Union{January, March, May, Day(1), Day(Last)}
-// 	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
-// 	for n := 0; n < b.N; n++ {
-// 		ch := d.Occurrences(tr)
-// 		for {
-// 			_, ok := <-ch
-//
-// 			if !ok {
-// 				break
-// 			}
-// 		}
-// 	}
-// }
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestUnion(t *testing.T) {
+	u := Union{
+		OrdinalWeekday(First, Sunday),
+		Day(Last),
+	}
+	r := YearRange(2006)
+
+	assertIsOnlyOccurring(t, r, u, "2006-01-01", "2006-02-05", "2006-03-05",
+		"2006-04-02", "2006-05-07", "2006-06-04", "2006-07-02", "2006-08-06",
+		"2006-09-03", "2006-10-01", "2006-11-05", "2006-12-03", "2006-01-31",
+		"2006-02-28", "2006-03-31", "2006-04-30", "2006-05-31", "2006-06-30",
+		"2006-07-31", "2006-08-31", "2006-09-30", "2006-10-31", "2006-11-30",
+		"2006-12-31")
+}
+
+func TestUnionOccurrences(t *testing.T) {
+	tr := TimeRange{time.Time(NewDate("2006-01-01")), time.Time(NewDate("2009-12-31"))}
+
+	expectations := map[int]Schedule{
+		368: Union{June, July, August},
+		626: Union{Monday, Wednesday, Friday},
+		209: Union{Monday, Monday}, // Shouldn't duplicate days
+	}
+
+	assertOccurrenceGeneration2(t, tr, expectations)
+}
+
+func TestUnionMarshalJSON(t *testing.T) {
+	tests := map[string]Union{
+		`{"union":[{"day":1},{"day":"Last"},{"month":"January"}]}`:         Union{Day(First), Day(Last), January},
+		`{"union":[{"weekday":"Thursday"},{"week":"Last"},{"year":2012}]}`: Union{Thursday, Week(Last), Year(2012)},
+	}
+
+	for expected, input := range tests {
+		output, err := json.Marshal(input)
+		if string(output) != expected || err != nil {
+			t.Errorf("\nInput: %v\nExpected: %v\nActual: %v\nError: %v", input, expected, string(output), err)
+		}
+	}
+}
+
+func TestUnionUnmarshalJSON(t *testing.T) {
+	tests := map[string]Union{
+		`[{"day":"Last"},{"month":"January"}]`:   Union{Day(Last), January},
+		`[{"weekday":"Thursday"},{"year":2014}]`: Union{Thursday, Year(2014)},
+	}
+
+	for input, expected := range tests {
+		var output Union
+		err := json.Unmarshal([]byte(input), &output)
+		if !reflect.DeepEqual(output, expected) || err != nil {
+			t.Errorf("\nInput: %v\nExpected: %v\nActual: %v\nError: %v", input, expected, output, err)
+		}
+	}
+}
+
+func BenchmarkUnionOccurrences(b *testing.B) {
+	d := Union{January, March, May, Day(1), Day(Last)}
+	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
+	for n := 0; n < b.N; n++ {
+		d.Occurrences(tr)
+	}
+}

--- a/week.go
+++ b/week.go
@@ -41,7 +41,7 @@ func (self Week) IsOccurring(t time.Time) bool {
 }
 
 // Implement Schedule interface.
-func (self Week) Occurrences(tr TimeRange) chan time.Time {
+func (self Week) Occurrences(tr TimeRange) []time.Time {
 	return occurrencesFor(self, tr)
 }
 

--- a/week_test.go
+++ b/week_test.go
@@ -91,13 +91,6 @@ func BenchmarkWeekOccurrences(b *testing.B) {
 			w = Week(run)
 		}
 
-		ch := w.Occurrences(tr)
-		for {
-			_, ok := <-ch
-
-			if !ok {
-				break
-			}
-		}
+		w.Occurrences(tr)
 	}
 }

--- a/weekday.go
+++ b/weekday.go
@@ -30,7 +30,7 @@ func (self Weekday) IsOccurring(t time.Time) bool {
 }
 
 // Implement Schedule interface.
-func (self Weekday) Occurrences(tr TimeRange) chan time.Time {
+func (self Weekday) Occurrences(tr TimeRange) []time.Time {
 	return occurrencesFor(self, tr)
 }
 

--- a/weekday_test.go
+++ b/weekday_test.go
@@ -97,13 +97,6 @@ func BenchmarkWeekdayOccurrences(b *testing.B) {
 	d := Thursday
 	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
 	for n := 0; n < b.N; n++ {
-		ch := d.Occurrences(tr)
-		for {
-			_, ok := <-ch
-
-			if !ok {
-				break
-			}
-		}
+		d.Occurrences(tr)
 	}
 }

--- a/year.go
+++ b/year.go
@@ -20,7 +20,7 @@ func (self Year) IsOccurring(t time.Time) bool {
 }
 
 // Implement Schedule interface.
-func (self Year) Occurrences(tr TimeRange) chan time.Time {
+func (self Year) Occurrences(tr TimeRange) []time.Time {
 	return occurrencesFor(self, tr)
 }
 

--- a/year_test.go
+++ b/year_test.go
@@ -79,13 +79,6 @@ func BenchmarkYearOccurrences(b *testing.B) {
 	d := Year(2525)
 	tr := TimeRange{time.Now(), time.Now().AddDate(1000, 0, 0)}
 	for n := 0; n < b.N; n++ {
-		ch := d.Occurrences(tr)
-		for {
-			_, ok := <-ch
-
-			if !ok {
-				break
-			}
-		}
+		d.Occurrences(tr)
 	}
 }


### PR DESCRIPTION
- [x] Added `HourMinuteSecond` occurence type
- [x] Removed need for goroutine in some function
- [x] Functions do not return a channel anymore but slices of `time.Time`

Let me know what you think - I think however that adding channels and doing code within goroutines is a step too far in premature optimization 😸 . The code is fast enough with just iteration and having the caller wait for the full slice.
